### PR TITLE
Refresh connection on connection reset

### DIFF
--- a/pyle38/client.py
+++ b/pyle38/client.py
@@ -150,7 +150,7 @@ class Client:
         for the connection.
         """
         await connection.on_connect()
-        self.format = Format.RESP.value
+        self.__format = Format.RESP.value
 
     async def __delete_response_callbacks(self):
         """Delete response callbacks in redis-py

--- a/pyle38/errors.py
+++ b/pyle38/errors.py
@@ -2,6 +2,10 @@ class Tile38Error(Exception):
     pass
 
 
+class Tile38ParseError(Tile38Error):
+    pass
+
+
 class Tile38IdNotFoundError(Exception):
     pass
 

--- a/pyle38/parse_response.py
+++ b/pyle38/parse_response.py
@@ -5,6 +5,7 @@ from redis.typing import EncodableT
 
 from .errors import (
     Tile38Error,
+    Tile38ParseError,
     Tile38IdNotFoundError,
     Tile38KeyNotFoundError,
     Tile38NotCaughtUpError,
@@ -18,12 +19,12 @@ def parse_response(
     ] = None,
 ) -> Dict[str, Union[float, str, int, list, dict]]:
     if not isinstance(response, str) or isinstance(response, bytes):
-        raise Tile38Error("invalid response")
+        raise Tile38ParseError("invalid response")
 
     try:
         obj = json.loads(response)
     except Exception as e:
-        raise Tile38Error(e)
+        raise Tile38ParseError(e)
 
     msg = "unknown"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -53,3 +53,18 @@ async def test_client_quit():
     response = await client.quit()
 
     assert response == "OK"
+
+
+@pytest.mark.asyncio
+async def test_client_handles_disconnection():
+    client = Client(os.getenv("TILE38_LEADER_URI") or "redis://localhost:9851")
+
+    response = await client.command("SET", ["fleet", "truck", "POINT", 1, 1])
+    assert response["ok"]
+
+    await client._Client__redis.aclose()
+
+    response = await client.command("SET", ["fleet", "truck", "POINT", 1, 1])
+    assert response["ok"]
+
+    await client.quit()


### PR DESCRIPTION
Hello! Thank you for this library and happy hacktoberfest I guess 🎃

I have encountered an issue where if the connection is reset while you have a long running connection open, unexpected behaviour can start to occur.

```python
import asyncio
from pyle38 import Tile38

client = Tile38("redis://localhost:9851")

async def main():
    while True:
        try:
            print(await client.command("SET", ["fleet", "truck", "POINT", 1, 1]))
        except Exception as e:
            print(e)
        await asyncio.sleep(1)

asyncio.run(main())
```

Running the above and restarting the Docker container running Tile38 while it's running produces output as such

```
{'ok': True, 'elapsed': '202.166µs'}
{'ok': True, 'elapsed': '22.083µs'}
{'ok': True, 'elapsed': '33.25µs'}
Connection closed by server.
Error UNKNOWN while writing to socket. Connection lost.
Expecting value: line 1 column 1 (char 0)
Expecting value: line 1 column 1 (char 0)
Expecting value: line 1 column 1 (char 0)
```

The `Redis` object will throw a `redis.ConnectionError` if it attempts to use a closed connection the next time it is used. On the subsequent call everything will be fine. However, the `OUTPUT JSON` command has been lost!

From the output above you can see the errors are thrown by redis-py - then when the connection is available again the response is unable to be parsed as it's just `"OK"`.

To illustrate in a different way:

```python
await client.command("SET", ["fleet", "truck", "POINT", 1, 1])  # ok
# Restart Tile38 and wait for it to be available again
await client.command("SET", ["fleet", "truck", "POINT", 1, 1])  # ConnectionError
await client.command("SET", ["fleet", "truck", "POINT", 1, 1])  # JSON parse error
```

The time between the first command and the second command doesn't matter. If you restart the Tile38 server and wait for 1 minute the second call will still be a connection error - at which point the connection internal to `Redis` is reset.

---

This provides a couple of potential fixes.

First, it enables `retry_on_error` for the Redis client. This should address the `ConnectionError` when making a request after a dropped connection. I've set this to `Retry(ExponentialBackoff(), 10)` which is about 3 seconds.

Second, if there's a parse error in `parse_response` retry the call and reset the format. For this I added some basic retry logic as I didn't want to add a new dependency for this one use case.

I've added a test that addresses the parse issue after a connection reset, but the `ConnectionError` is hard to test as it relies on dropping the connection outside of the client.