### PR TITLE
feat: ✨ client connection options

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,26 @@ send to the follower, by adding `.follower()` to your command chaining.
 await tile38.follower().get('fleet', 'truck1').asObject()
 ```
 
+### Client Connection Configuration
+
+Pyle38 allows to add (a handful) of custom client connection
+settings to be modified.
+
+```python
+from pyle38 import Tile38
+from pyle38.client_config import WithRetryExponentialBackoff, WithRetryOnError
+from pyle38.errors import Pyle38TimeoutError, Pyle38ConnectionError
+tile38 = Tile38(
+    url='redis://localhost:9851',
+    options=[
+        # for 10 retries
+        WithRetryExponentialBackoff(10),
+        # retries the following errors
+        WithRetryOnError(Pyle38ConnectionError, Pyle38TimeoutError),
+    ]
+)
+```
+
 ### Pagination
 
 Tile38 has hidden limits set for the amount of objects that can be returned

--- a/pyle38/client.py
+++ b/pyle38/client.py
@@ -153,6 +153,15 @@ class Client:
         for option in default_options:
             self.__client_options = option(self.__client_options)
 
+    @property
+    def url(self) -> str:
+        """The client url
+
+        Returns:
+            str: returns the clients url
+        """
+        return self.__url
+
     def client_options(self) -> ClientOptions:
         """Get the current ClientOptions.
 

--- a/pyle38/client.py
+++ b/pyle38/client.py
@@ -130,6 +130,7 @@ class Client:
 
     __redis = None
     __client_options: ClientOptions = {}
+    __url = ""
 
     def __init__(
         self, url: str, options: List[Callable[..., ClientOptions]] = []
@@ -143,7 +144,7 @@ class Client:
         Returns:
             None
         """
-        self.url = url
+        self.__url = url
         self.__redis = None
 
         default_options: List = []
@@ -201,7 +202,7 @@ class Client:
             redis.Redis: The Redis connection instance.
         """
         if not self.__redis:
-            url_components = parse_url(self.url)
+            url_components = parse_url(self.__url)
             host: str = url_components.get("host") or TILE38_DEFAULT_HOST
             port: int = url_components.get("port") or TILE38_DEFAULT_PORT
 

--- a/pyle38/client_options.py
+++ b/pyle38/client_options.py
@@ -1,0 +1,46 @@
+from typing import Callable, List
+
+from redis.asyncio.retry import Retry
+from redis.backoff import ExponentialBackoff
+from typing_extensions import NotRequired, TypedDict
+
+from .errors import Pyle38Error
+
+Pyle38Retry = Retry
+Pyle38ExponentialBackoff = ExponentialBackoff
+
+ClientOptions = TypedDict(
+    "ClientOptions",
+    {
+        "retry": NotRequired[Pyle38Retry],
+        "retry_on_error": NotRequired[List[type[Pyle38Error]]],
+    },
+)
+
+
+def WithRetryExponentialBackoff(retries: int) -> Callable[..., ClientOptions]:
+    try:
+        t = int(retries)
+    except ValueError:
+        raise ValueError("Retries must be a positive integer")
+
+    if t < 0:
+        raise ValueError("Retries must be a positive integer")
+
+    def _with_retry_exponential_backoff(opts: ClientOptions) -> ClientOptions:
+        opts["retry"] = Pyle38Retry(Pyle38ExponentialBackoff(), retries=retries)
+        return opts
+
+    return _with_retry_exponential_backoff
+
+
+def WithRetryOnError(
+    *errs: type[Pyle38Error],
+) -> Callable[..., ClientOptions]:
+    def _with_retry_on_error(opts: ClientOptions) -> ClientOptions:
+        opts["retry_on_error"] = []
+        if len(errs) > 0:
+            opts["retry_on_error"] = list(errs)
+        return opts
+
+    return _with_retry_on_error

--- a/pyle38/client_options.py
+++ b/pyle38/client_options.py
@@ -19,6 +19,21 @@ ClientOptions = TypedDict(
 
 
 def WithRetryExponentialBackoff(retries: int) -> Callable[..., ClientOptions]:
+    """Return a callable that configures exponential backoff for retries.
+
+    This function creates and returns a callable that, when invoked, will configure
+    retry behavior with exponential backoff for the given number of retries.
+
+    Args:
+        retries (int): The number of retry attempts to make.
+
+    Raises:
+        ValueError: If the retries argument is not a positive integer.
+
+    Returns:
+        Callable[..., ClientOptions]: A function that accepts `ClientOptions` and
+        configures exponential backoff retry with the specified number of retries.
+    """
     try:
         t = int(retries)
     except ValueError:
@@ -28,6 +43,17 @@ def WithRetryExponentialBackoff(retries: int) -> Callable[..., ClientOptions]:
         raise ValueError("Retries must be a positive integer")
 
     def _with_retry_exponential_backoff(opts: ClientOptions) -> ClientOptions:
+        """Helper function to update options with retry strategy.
+
+        This function modifies the `ClientOptions` by setting the `retry` field
+        to the configured exponential backoff retry strategy.
+
+        Args:
+            opts (ClientOptions): The current client options to update.
+
+        Returns:
+            ClientOptions: The updated client options with retry configuration.
+        """
         opts["retry"] = Pyle38Retry(Pyle38ExponentialBackoff(), retries=retries)
         return opts
 
@@ -37,7 +63,31 @@ def WithRetryExponentialBackoff(retries: int) -> Callable[..., ClientOptions]:
 def WithRetryOnError(
     *errs: type[Pyle38Error],
 ) -> Callable[..., ClientOptions]:
+    """Return a callable that configures retry behavior based on specific errors.
+
+    This function creates and returns a callable that, when invoked, will configure
+    the retry behavior to only retry on the specified error types.
+
+    Args:
+        *errs (type[Pyle38Error]): One or more error types to retry on.
+
+    Returns:
+        Callable[..., ClientOptions]: A function that accepts `ClientOptions` and
+        configures the retry behavior based on the specified error types.
+    """
+
     def _with_retry_on_error(opts: ClientOptions) -> ClientOptions:
+        """Helper function to update options with error-based retry configuration.
+
+        This function modifies the `ClientOptions` by setting the `retry_on_error`
+        field to the provided list of error types that should trigger retries.
+
+        Args:
+            opts (ClientOptions): The current client options to update.
+
+        Returns:
+            ClientOptions: The updated client options with error-based retry configuration.
+        """
         opts["retry_on_error"] = []
         if len(errs) > 0:
             opts["retry_on_error"] = list(errs)

--- a/pyle38/errors.py
+++ b/pyle38/errors.py
@@ -1,3 +1,10 @@
+from redis.exceptions import ConnectionError, RedisError, TimeoutError
+
+Pyle38Error = RedisError
+Pyle38ConnectionError = ConnectionError
+Pyle38TimeoutError = TimeoutError
+
+
 class Tile38Error(Exception):
     pass
 

--- a/pyle38/follower.py
+++ b/pyle38/follower.py
@@ -1,6 +1,9 @@
 from typing import List, Literal, Optional, Union
 
+from typing_extensions import Callable
+
 from .client import Client, Command, SubCommand
+from .client_options import ClientOptions
 from .commands.get import Get
 from .commands.intersects import Intersects
 from .commands.nearby import Nearby
@@ -26,15 +29,14 @@ from .responses import (
 )
 
 
-class Follower(Client):
+class Follower:
     client: Client
 
-    def __init__(self, url: str) -> None:
+    def __init__(self, url: str, *opts: Callable[..., ClientOptions]) -> None:
         if not url:
             raise Tile38Error("No Tile38 follower uri set")
-        super().__init__(url)
 
-        self.client = Client(url)
+        self.client = Client(url, *opts)
 
     async def exists(self, key: str, id: str) -> ExistsResponse:
         return ExistsResponse(**(await self.client.command(Command.EXISTS, [key, id])))

--- a/pyle38/follower.py
+++ b/pyle38/follower.py
@@ -1,6 +1,4 @@
-from typing import List, Literal, Optional, Union
-
-from typing_extensions import Callable
+from typing import Callable, List, Literal, Optional, Union
 
 from .client import Client, Command, SubCommand
 from .client_options import ClientOptions
@@ -30,29 +28,107 @@ from .responses import (
 
 
 class Follower:
+    """
+    A class to interact with a Tile38 follower instance using various Tile38 commands.
+
+    Attributes:
+        client (Client): An instance of the Client class for connecting to Tile38.
+    """
+
     client: Client
 
-    def __init__(self, url: str, *opts: Callable[..., ClientOptions]) -> None:
-        if not url:
-            raise Tile38Error("No Tile38 follower uri set")
+    def __init__(self, url: str, opts: List[Callable[..., ClientOptions]] = []) -> None:
+        """Initialize the Follower client.
 
-        self.client = Client(url, *opts)
+        Args:
+            url (str): The URL for connecting to the Tile38 follower server.
+            opts (List[Callable[..., ClientOptions]], optional): A list of callables that modify client options.
+
+        Raises:
+            Tile38Error: If the follower URL is not provided.
+        """
+        if not url:
+            raise Tile38Error("No Tile38 follower URI set")
+
+        self.client = Client(url, opts)
+
+    async def aofshrink(self) -> JSONResponse:
+        """Shrink the append only file on"""
+        return JSONResponse(**(await self.client.command(Command.AOFSHRINK)))
 
     async def exists(self, key: str, id: str) -> ExistsResponse:
+        """Check if an object exists in a collection.
+
+        Tile38 Command:
+            EXISTS key id
+
+        Args:
+            key (str): The collection key.
+            id (str): The object ID.
+
+        Returns:
+            ExistsResponse: Response indicating if the object exists.
+        """
         return ExistsResponse(**(await self.client.command(Command.EXISTS, [key, id])))
 
     async def fexists(self, key: str, id: str, field: str) -> ExistsResponse:
+        """Check if a field exists within an object.
+
+        Tile38 Command:
+            FEXISTS key id field
+
+        Args:
+            key (str): The collection key.
+            id (str): The object ID.
+            field (str): The field name.
+
+        Returns:
+            ExistsResponse: Response indicating if the field exists.
+        """
         return ExistsResponse(
             **(await self.client.command(Command.FEXISTS, [key, id, field]))
         )
 
     async def bounds(self, key: str) -> BoundsResponse:
+        """Get the bounds of a collection.
+
+        Tile38 Command:
+            BOUNDS key
+
+        Args:
+            key (str): The collection key.
+
+        Returns:
+            BoundsResponse: The bounding box of the specified collection.
+        """
         return BoundsResponse(**(await self.client.command(Command.BOUNDS, [key])))
 
     async def chans(self, pattern: str = "*") -> ChansResponse:
+        """List active channels.
+
+        Tile38 Command:
+            CHANS pattern
+
+        Args:
+            pattern (str, optional): The pattern to match channel names.
+
+        Returns:
+            ChansResponse: A list of active channels.
+        """
         return ChansResponse(**(await self.client.command(Command.CHANS, [pattern])))
 
     async def config_get(self, name: ConfigKeys) -> ConfigGetResponse:
+        """Get a configuration value.
+
+        Tile38 Command:
+            CONFIG GET name
+
+        Args:
+            name (ConfigKeys): The configuration key.
+
+        Returns:
+            ConfigGetResponse: The value of the requested configuration key.
+        """
         return ConfigGetResponse(
             **(await self.client.command(Command.CONFIG, [Command.GET, name]))
         )
@@ -60,32 +136,124 @@ class Follower:
     async def config_set(
         self, name: ConfigKeys, value: Union[str, int, float]
     ) -> JSONResponse:
+        """Set a configuration value.
+
+        Tile38 Command:
+            CONFIG SET name value
+
+        Args:
+            name (ConfigKeys): The configuration key.
+            value (Union[str, int, float]): The value to set.
+
+        Returns:
+            JSONResponse: Confirmation of the configuration update.
+        """
         return JSONResponse(
             **(await self.client.command(Command.CONFIG, [Command.SET, name, value]))
         )
 
     async def config_rewrite(self) -> JSONResponse:
+        """Rewrite the configuration file.
+
+        Tile38 Command:
+            CONFIG REWRITE
+
+        Returns:
+            JSONResponse: Confirmation of the rewrite.
+        """
         return JSONResponse(
             **(await self.client.command(Command.CONFIG, [SubCommand.REWRITE]))
         )
 
     async def gc(self) -> JSONResponse:
+        """Trigger garbage collection.
+
+        Tile38 Command:
+            GC
+
+        Returns:
+            JSONResponse: Confirmation of garbage collection.
+        """
         return JSONResponse(**(await self.client.command(Command.GC)))
 
     def get(self, key: str, id: str) -> Get:
+        """Get a specific object.
+
+        Tile38 Command:
+            GET key id
+
+        Args:
+            key (str): The collection key.
+            id (str): The object ID.
+
+        Returns:
+            Get: An object that allows retrieving data from Tile38.
+        """
         return Get(self.client, key, id)
 
     async def hooks(self, pattern: str = "*") -> HooksResponse:
+        """List active hooks.
+
+        Tile38 Command:
+            HOOKS pattern
+
+        Args:
+            pattern (str, optional): The pattern to match hook names.
+
+        Returns:
+            HooksResponse: A list of active hooks.
+        """
         return HooksResponse(**(await self.client.command(Command.HOOKS, [pattern])))
 
     async def healthz(self) -> JSONResponse:
+        """Check the health of the Tile38 server.
+
+        Tile38 Command:
+            HEALTHZ
+
+        Returns:
+            JSONResponse: Server health status.
+        """
         return JSONResponse(**(await self.client.command(Command.HEALTHZ)))
 
     async def info(self) -> InfoFollowerResponse:
+        """Get server information.
+
+        Tile38 Command:
+            INFO
+
+        Returns:
+            InfoFollowerResponse: Server information and statistics.
+        """
         return InfoFollowerResponse(**(await self.client.command(Command.INFO)))
 
     def intersects(self, key: str) -> Intersects:
+        """Query objects that intersect a specified area.
+
+        Tile38 Command:
+            INTERSECTS
+
+        Args:
+            key (str): The collection key.
+
+        Returns:
+            Intersects: An object to perform intersection queries.
+        """
         return Intersects(self.client, key)
+
+    async def keys(self, pattern: str = "*") -> KeysResponse:
+        """List keys matching a pattern.
+
+        Tile38 Command:
+            KEYS pattern
+
+        Args:
+            pattern (str, optional): The pattern to match keys.
+
+        Returns:
+            KeysResponse: A list of matching keys.
+        """
+        return KeysResponse(**(await self.client.command(Command.KEYS, [pattern])))
 
     async def jget(
         self,
@@ -94,6 +262,20 @@ class Follower:
         path: Optional[str] = None,
         mode: Optional[Literal["RAW"]] = None,
     ) -> JSONGetResponse:
+        """Get a JSON field.
+
+        Tile38 Command:
+            JGET key id [path] [RAW]
+
+        Args:
+            key (str): The collection key.
+            id (str): The object ID.
+            path (Optional[str], optional): The JSON path.
+            mode (Optional[Literal["RAW"]], optional): RAW mode for unparsed output.
+
+        Returns:
+            JSONGetResponse: The requested JSON data.
+        """
         return JSONGetResponse(
             **(
                 await self.client.command(
@@ -103,43 +285,124 @@ class Follower:
             )
         )
 
-    async def keys(self, pattern: str = "*") -> KeysResponse:
-        return KeysResponse(**(await self.client.command(Command.KEYS, [pattern])))
-
     def nearby(self, key: str) -> Nearby:
+        """Find objects near a specified location.
+
+        Tile38 Command:
+            NEARBY
+
+        Args:
+            key (str): The collection key.
+
+        Returns:
+            Nearby: An object to perform nearby queries.
+        """
         return Nearby(self.client, key)
 
     async def ping(self) -> PingResponse:
+        """Ping the Tile38 server.
+
+        Tile38 Command:
+            PING
+
+        Returns:
+            PingResponse: Ping response from the server.
+        """
         return PingResponse(**(await self.client.command(Command.PING)))
 
     def scan(self, key: str) -> Scan:
+        """Scan a collection.
+
+        Tile38 Command:
+            SCAN
+
+        Args:
+            key (str): The collection key.
+
+        Returns:
+            Scan: An object to perform scan queries.
+        """
         return Scan(self.client, key)
 
     def search(self, key: str) -> Search:
+        """Search a collection.
+
+        Tile38 Command:
+            SEARCH key
+
+        Args:
+            key (str): The collection key.
+
+        Returns:
+            Search: An object to perform search queries.
+        """
         return Search(self.client, key)
 
     async def server(self) -> ServerStatsResponseFollower:
+        """Get server stats.
+
+        Tile38 Command:
+            SERVER
+
+        Returns:
+            ServerStatsResponseFollower: Basic server statistics.
+        """
         return ServerStatsResponseFollower(
             **(await self.client.command(Command.SERVER))
         )
 
     async def server_extended(self) -> ServerStatsExtendedResponse:
+        """Get extended server stats.
+
+        Tile38 Command:
+            SERVER
+
+        Returns:
+            ServerStatsExtendedResponse: Extended server statistics.
+        """
         return ServerStatsExtendedResponse(
             **(await self.client.command(Command.SERVER, [SubCommand.EXT]))
         )
 
     async def stats(self, keys: List[str]) -> StatsResponse:
-        response = await self.client.command(Command.STATS, keys)
+        """Get statistics for specified keys.
 
+        Tile38 Command:
+            STATS key...
+
+        Args:
+            keys (List[str]): A list of keys to get statistics for.
+
+        Returns:
+            StatsResponse: Statistics for the given keys.
+        """
+        response = await self.client.command(Command.STATS, keys)
         if response["stats"] == [None]:
             response["stats"] = []
-
         return StatsResponse(**response)
 
     async def quit(self) -> str:
-        await self.client.quit()
+        """Disconnect from Tile38.
 
+        Tile38 Command:
+            QUIT
+
+        Returns:
+            str: A confirmation message ("OK") upon successful termination.
+        """
+        await self.client.quit()
         return "OK"
 
     def within(self, key: str) -> Within:
+        """Query objects within a specified area.
+
+        Tile38 Command:
+            WITHIN
+
+        Args:
+            key (str): The collection key.
+
+        Returns:
+            Within: An object to perform within-area queries.
+        """
         return Within(self.client, key)

--- a/pyle38/leader.py
+++ b/pyle38/leader.py
@@ -16,19 +16,85 @@ from .responses import (
 
 
 class Leader(Follower):
+    """
+    A class to interact with a Tile38 leader instance, extending the Follower class
+    with additional write and administrative commands.
+
+    Attributes:
+        client (Client): An instance of the Client class for connecting to Tile38.
+    """
+
     async def delete(self, key: str, id: str) -> JSONResponse:
+        """Delete an object from a collection.
+
+        Tile38 Command:
+            DEL key id
+
+        Args:
+            key (str): The collection key.
+            id (str): The object ID.
+
+        Returns:
+            JSONResponse: Confirmation of deletion.
+        """
         return JSONResponse(**(await self.client.command(Command.DEL, [key, id])))
 
     async def delchan(self, name: str) -> JSONResponse:
+        """Delete a channel.
+
+        Tile38 Command:
+            DELCHAN name
+
+        Args:
+            name (str): The channel name.
+
+        Returns:
+            JSONResponse: Confirmation of channel deletion.
+        """
         return JSONResponse(**(await self.client.command(Command.DELCHAN, [name])))
 
     async def delhook(self, name: str) -> JSONResponse:
+        """Delete a geofence hook.
+
+        Tile38 Command:
+            DELHOOK name
+
+        Args:
+            name (str): The hook name.
+
+        Returns:
+            JSONResponse: Confirmation of hook deletion.
+        """
         return JSONResponse(**(await self.client.command(Command.DELHOOK, [name])))
 
     async def drop(self, key: str) -> JSONResponse:
+        """Drop an entire collection.
+
+        Tile38 Command:
+            DROP key
+
+        Args:
+            key (str): The collection key.
+
+        Returns:
+            JSONResponse: Confirmation of collection drop.
+        """
         return JSONResponse(**(await self.client.command(Command.DROP, [key])))
 
     async def expire(self, key: str, id: str, seconds: int) -> JSONResponse:
+        """Set an expiration time for an object.
+
+        Tile38 Command:
+            EXPIRE key id seconds
+
+        Args:
+            key (str): The collection key.
+            id (str): The object ID.
+            seconds (int): The expiration time in seconds.
+
+        Returns:
+            JSONResponse: Confirmation of expiration set.
+        """
         # TODO: fix mypy
         # for reasons unknown [key, id, seconds] has type List[object]
         # and fails mypy validation
@@ -38,12 +104,41 @@ class Leader(Follower):
         return JSONResponse(**response)
 
     async def flushdb(self) -> JSONResponse:
+        """Delete all data from the Tile38 database.
+
+        Tile38 Command:
+            FLUSHDB
+
+        Returns:
+            JSONResponse: Confirmation of database flush.
+        """
         return JSONResponse(**(await self.client.command(Command.FLUSHDB)))
 
     def fset(self, key: str, id: str, fields: Fields) -> Fset:
+        """Set fields on an existing object.
+
+        Tile38 Command:
+            FSET key id field value...
+
+        Args:
+            key (str): The collection key.
+            id (str): The object ID.
+            fields (Fields): The fields to set.
+
+        Returns:
+            Fset: An object to perform field set operations.
+        """
         return Fset(self.client, key, id, fields)
 
     async def info(self) -> InfoLeaderResponse:  # type: ignore
+        """Get detailed server information specific to the leader.
+
+        Tile38 Command:
+            INFO
+
+        Returns:
+            InfoLeaderResponse: Server information and statistics.
+        """
         return InfoLeaderResponse(**(await self.client.command(Command.INFO)))
 
     async def jset(
@@ -54,6 +149,21 @@ class Leader(Follower):
         value: str,
         mode: Optional[Literal["RAW", "STR"]] = None,
     ) -> JSONResponse:
+        """Set a JSON value in an object.
+
+        Tile38 Command:
+            JSET key id path value [RAW|STR]
+
+        Args:
+            key (str): The collection key.
+            id (Union[str, int]): The object ID.
+            path (str): The JSON path.
+            value (str): The value to set.
+            mode (Optional[Literal["RAW", "STR"]]): Mode for setting value.
+
+        Returns:
+            JSONResponse: Confirmation of JSON value set.
+        """
         return JSONResponse(
             **(
                 await self.client.command(
@@ -63,48 +173,181 @@ class Leader(Follower):
         )
 
     async def jdel(self, key: str, id: str, path: str) -> JSONResponse:
+        """Delete a JSON value from an object.
+
+        Tile38 Command:
+            JDEL key id path
+
+        Args:
+            key (str): The collection key.
+            id (str): The object ID.
+            path (str): The JSON path.
+
+        Returns:
+            JSONResponse: Confirmation of JSON value deletion.
+        """
         return JSONResponse(
             **(await self.client.command(Command.JDEL, [key, id, path]))
         )
 
     async def pdel(self, key: str, pattern: str) -> JSONResponse:
+        """Delete objects matching a pattern.
+
+        Tile38 Command:
+            PDEL key pattern
+
+        Args:
+            key (str): The collection key.
+            pattern (str): The pattern to match IDs.
+
+        Returns:
+            JSONResponse: Confirmation of pattern-based deletion.
+        """
         return JSONResponse(**(await self.client.command(Command.PDEL, [key, pattern])))
 
     async def pdelchan(self, pattern: str) -> JSONResponse:
+        """Delete channels matching a pattern.
+
+        Tile38 Command:
+            PDELCHAN pattern
+
+        Args:
+            pattern (str): The pattern to match channel names.
+
+        Returns:
+            JSONResponse: Confirmation of channel deletion.
+        """
         return JSONResponse(**(await self.client.command(Command.PDELCHAN, [pattern])))
 
     async def pdelhook(self, pattern: str) -> JSONResponse:
+        """Delete hook matching a pattern.
+
+        Tile38 Command:
+            PDELHOOK pattern
+
+        Args:
+            pattern (str): The pattern to match hook names.
+
+        Returns:
+            JSONResponse: Confirmation of hook deletion.
+        """
         return JSONResponse(**(await self.client.command(Command.PDELHOOK, [pattern])))
 
     async def persist(self, key: str, id: str) -> JSONResponse:
+        """Remove expiration from an object.
+
+        Tile38 Command:
+            PERSIST key id
+
+        Args:
+            key (str): The collection key.
+            id (str): The object ID.
+
+        Returns:
+            JSONResponse: Confirmation of persistence.
+        """
         return JSONResponse(**(await self.client.command(Command.PERSIST, [key, id])))
 
     async def readonly(self, value=True) -> JSONResponse:
+        """Set the server to readonly mode.
+
+        Tile38 Command:
+            READONLY yes|no
+
+        Args:
+            value (bool): True to enable readonly mode, False to disable.
+
+        Returns:
+            JSONResponse: Confirmation of readonly status.
+        """
         return JSONResponse(
             **(await self.client.command(Command.READONLY, ["yes" if value else "no"]))
         )
 
     async def rename(self, key: str, newkey: str, nx=False) -> JSONResponse:
-        if nx:
-            return JSONResponse(
-                **(await self.client.command(Command.RENAMENX, [key, newkey]))
-            )
+        """Rename a collection key.
 
-        return JSONResponse(
-            **(await self.client.command(Command.RENAME, [key, newkey]))
-        )
+        Tile38 Command:
+            RENAME key newkey
+            RENAMENX key newkey
+
+        Args:
+            key (str): The current collection key.
+            newkey (str): The new collection key.
+            nx (bool): If True, rename only if the new key does not exist.
+
+        Returns:
+            JSONResponse: Confirmation of key renaming.
+        """
+        command = Command.RENAMENX if nx else Command.RENAME
+        return JSONResponse(**(await self.client.command(command, [key, newkey])))
 
     def set(self, key: str, id: str) -> Set:
+        """Set an object in a collection.
+
+        Tile38 Command:
+            SET key id
+
+        Args:
+            key (str): The collection key.
+            id (str): The object ID.
+
+        Returns:
+            Set: An object to perform set operations.
+        """
         return Set(self.client, key, id)
 
     async def server(self) -> ServerStatsResponseLeader:  # type: ignore
+        """Get server stats specific to the leader.
+
+        Tile38 Command:
+            SERVER
+
+        Returns:
+            ServerStatsResponseLeader: Server statistics.
+        """
         return ServerStatsResponseLeader(**(await self.client.command(Command.SERVER)))
 
     def sethook(self, name: str, endpoint: str) -> SetHook:
+        """Set a geofence hook.
+
+        Tile38 Command:
+            SETHOOK name endpoint
+
+        Args:
+            name (str): The hook name.
+            endpoint (str): The endpoint URL.
+
+        Returns:
+            SetHook: An object to configure the hook.
+        """
         return SetHook(self.client, name, endpoint)
 
     def setchan(self, name: str) -> SetChan:
+        """Create a pub/sub channel.
+
+        Tile38 Command:
+            SETCHAN name
+
+        Args:
+            name (str): The channel name.
+
+        Returns:
+            SetChan: An object to configure the channel.
+        """
         return SetChan(self.client, name)
 
     async def ttl(self, key: str, id: str) -> TTLResponse:
+        """Get the time-to-live (TTL) of an object.
+
+        Tile38 Command:
+            TTL key id
+
+        Args:
+            key (str): The collection key.
+            id (str): The object ID.
+
+        Returns:
+            TTLResponse: The TTL in seconds.
+        """
         return TTLResponse(**(await self.client.command(Command.TTL, [key, id])))

--- a/pyle38/tile38.py
+++ b/pyle38/tile38.py
@@ -1,5 +1,7 @@
 import os
-from typing import Optional
+from typing import Callable, Optional
+
+from pyle38.client_options import ClientOptions
 
 from .errors import Tile38Error
 from .follower import Follower
@@ -9,19 +11,19 @@ from .leader import Leader
 class Tile38(Leader):
     _follower: Optional[Follower] = None
 
-    # TODO: get url from os.getenv
     def __init__(
         self,
         url=os.getenv("TILE38_LEADER_URI"),
         follower_url=os.getenv("TILE38_FOLLOWER_URI"),
+        *opts: Callable[..., ClientOptions],
     ):
         if not url:
             raise Tile38Error("No Tile38 url set")
 
-        super().__init__(url)
+        super().__init__(url, *opts)
 
         if follower_url:
-            self._follower = Follower(follower_url)
+            self._follower = Follower(follower_url, *opts)
 
     def follower(self) -> Follower:
         if not self._follower:

--- a/pyle38/tile38.py
+++ b/pyle38/tile38.py
@@ -1,5 +1,5 @@
 import os
-from typing import Callable, Optional
+from typing import Callable, List, Optional
 
 from pyle38.client_options import ClientOptions
 
@@ -9,30 +9,69 @@ from .leader import Leader
 
 
 class Tile38(Leader):
-    _follower: Optional[Follower] = None
+    """
+    A class to manage a Tile38 leader instance with optional follower support.
+
+    Attributes:
+        __follower (Optional[Follower]): A private attribute holding the follower instance if a follower URL is provided.
+    """
+
+    __follower: Optional[Follower] = None
 
     def __init__(
         self,
         url=os.getenv("TILE38_LEADER_URI"),
         follower_url=os.getenv("TILE38_FOLLOWER_URI"),
-        *opts: Callable[..., ClientOptions],
+        options: List[Callable[..., ClientOptions]] = [],
     ):
+        """Initialize the Tile38 leader and optional follower.
+
+        Args:
+            url (str, optional): The URL for the Tile38 leader instance.
+                Defaults to the environment variable `TILE38_LEADER_URI`.
+            follower_url (str, optional): The URL for the Tile38 follower instance.
+                Defaults to the environment variable `TILE38_FOLLOWER_URI`.
+            options (List[Callable[..., ClientOptions]], optional): A list of callables
+                that return client options for configuring the Tile38 connection.
+
+        Raises:
+            Tile38Error: If the leader URL is not provided.
+
+        Returns:
+            None
+        """
         if not url:
             raise Tile38Error("No Tile38 url set")
 
-        super().__init__(url, *opts)
+        super().__init__(url, options)
 
         if follower_url:
-            self._follower = Follower(follower_url, *opts)
+            self.__follower = Follower(follower_url, options)
 
     def follower(self) -> Follower:
-        if not self._follower:
+        """Get the Tile38 follower instance.
+
+        Raises:
+            Tile38Error: If the follower instance is not available.
+
+        Returns:
+            Follower: The follower instance.
+        """
+        if not self.__follower:
             raise Tile38Error("No follower")
 
-        return self._follower
+        return self.__follower
 
     async def quit(self) -> str:
-        if self._follower:
+        """Asynchronously quit the Tile38 leader and follower connections.
+
+        This method first quits the follower connection (if available),
+        followed by quitting the leader connection.
+
+        Returns:
+            str: A confirmation message ("OK") upon successful termination.
+        """
+        if self.__follower:
             await self.follower().quit()
 
         await super().quit()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F"]
+extend-select = ["I"]
 ignore = ["E501"]
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,7 +23,7 @@ async def test_client_options():
         WithRetryOnError(Pyle38TimeoutError, Pyle38ConnectionError),
     ]
     client = Client(
-        os.getenv("TILE38_LEADER_URI") or "redis://localhost:9851", *client_options
+        os.getenv("TILE38_LEADER_URI") or "redis://localhost:9851", client_options
     )
 
     opts = client.client_options()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -18,13 +18,14 @@ from pyle38.errors import (
 
 @pytest.mark.asyncio
 async def test_client_options():
+    url = os.getenv("TILE38_LEADER_URI") or "redis://localhost:9851"
     client_options = [
         WithRetryExponentialBackoff(10),
         WithRetryOnError(Pyle38TimeoutError, Pyle38ConnectionError),
     ]
-    client = Client(
-        os.getenv("TILE38_LEADER_URI") or "redis://localhost:9851", client_options
-    )
+    client = Client(url, client_options)
+
+    assert client.url == url
 
     opts = client.client_options()
     assert opts["retry"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,8 +3,41 @@ import os
 import pytest
 
 from pyle38 import Tile38
-from pyle38.client import Client
-from pyle38.errors import Tile38Error, Tile38IdNotFoundError, Tile38KeyNotFoundError
+from pyle38.client import (
+    Client,
+)
+from pyle38.client_options import WithRetryExponentialBackoff, WithRetryOnError
+from pyle38.errors import (
+    Pyle38ConnectionError,
+    Pyle38TimeoutError,
+    Tile38Error,
+    Tile38IdNotFoundError,
+    Tile38KeyNotFoundError,
+)
+
+
+@pytest.mark.asyncio
+async def test_client_options():
+    client_options = [
+        WithRetryExponentialBackoff(10),
+        WithRetryOnError(Pyle38TimeoutError, Pyle38ConnectionError),
+    ]
+    client = Client(
+        os.getenv("TILE38_LEADER_URI") or "redis://localhost:9851", *client_options
+    )
+
+    opts = client.client_options()
+    assert opts["retry"]
+    assert type(opts["retry_on_error"]) is list
+    assert opts["retry_on_error"] == [Pyle38TimeoutError, Pyle38ConnectionError]
+
+    response = await client.command("SET", ["fleet", "truck", "POINT", 1, 1])
+    assert response["ok"]
+
+    response = await client.command("GET", ["fleet", "truck"])
+    assert response["ok"]
+
+    await client.quit()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
@alxwrd 

using options pattern redis client connection options. options pattern doesn't seem to be too widely used, yet it allows me to abstract away any of the redis retry and backoff implementations. the final version might look a little different, but I think you can test run this one to see if that suffices to close #529.

closes #529

UPDATE:

run

```bash
docker-compose up -d
```

start this in one terminal

```python
import asyncio

from pyle38 import Tile38
from pyle38.client_options import WithRetryExponentialBackoff, WithRetryOnError
from pyle38.errors import (
    Pyle38ConnectionError,
    Pyle38TimeoutError,
)

tile38 = Tile38(
    url="redis://localhost:9851",
    options=[
        WithRetryExponentialBackoff(30),
        WithRetryOnError(Pyle38TimeoutError, Pyle38ConnectionError),
    ]
)


async def main():
    while True:
        try:
            res = await tile38.set("fleet", "truck").point(1, 1).exec()
            print(res.dict())
        except Exception as e:
            print(e)

        await asyncio.sleep(1)


asyncio.run(main())
```

in another terminal restart the tile38 leader

```bash
docker-compose restart tile38-leader
```

as long as the leader comes back on within those 25 retries, the ConnectionError will not be raised.


